### PR TITLE
feat(media): replace imageUrl with media

### DIFF
--- a/app/api/campaigns/route.ts
+++ b/app/api/campaigns/route.ts
@@ -101,17 +101,6 @@ export async function POST(req: Request) {
         location: location || undefined,
         category: category || undefined,
         slug,
-        images: imageUrl
-          ? {
-              create: {
-                imageUrl,
-                isMainImage: true,
-              },
-            }
-          : undefined,
-      },
-      include: {
-        images: true,
       },
     });
     if (imageUrl) {

--- a/app/api/campaigns/user/route.ts
+++ b/app/api/campaigns/user/route.ts
@@ -101,9 +101,6 @@ export async function PATCH(req: Request) {
         description,
         location,
         category,
-        images: imageUrl
-          ? { create: { imageUrl, isMainImage: true } }
-          : undefined,
       },
     });
     if (imageUrl) {

--- a/components/campaign/card-create.tsx
+++ b/components/campaign/card-create.tsx
@@ -23,12 +23,14 @@ export function CampaignCardDashboardCreate({ onCreate }: CampaignItemProps) {
         <CampaignMainImage
           campaign={{
             title: 'Create Campaign',
-            images: [
+            media: [
               {
-                isMainImage: true,
-                imageUrl: '/images/campaign-create-card.jpg',
+                id: 'create-card',
+                url: '/images/campaign-create-card.jpg',
+                mimeType: 'image/jpg',
               },
             ],
+            mediaOrder: ['create-card'],
           }}
         />
       </CardHeader>

--- a/components/campaign/create/form-summary.tsx
+++ b/components/campaign/create/form-summary.tsx
@@ -28,14 +28,14 @@ export function CampaignCreateFormSummary() {
         category: values.category,
         createdAt: new Date(),
         updatedAt: new Date(),
-        images: [
+        media: [
           {
-            id: 0,
-            imageUrl: values.bannerImage,
-            isMainImage: true,
-            campaignId: 0,
+            id: 'unsaved',
+            url: values.bannerImage,
+            mimeType: 'image/unknown',
           },
         ],
+        mediaOrder: ['unsaved'],
         slug: 'summary-campaign',
         location: values.location,
 

--- a/components/campaign/create/process-display.tsx
+++ b/components/campaign/create/process-display.tsx
@@ -70,8 +70,8 @@ export function CampaignCreateProcessDisplay({
   const orderedStates: (keyof typeof CreateProcessStates)[] = useMemo(() => {
     return [
       'setup',
-      'validatingPlatform',
       'create',
+      'validatingPlatform',
       'createOnChain',
       'waitForCreationConfirmation',
       'updateDbCampaign',

--- a/components/campaign/edit/form-summary.tsx
+++ b/components/campaign/edit/form-summary.tsx
@@ -30,14 +30,14 @@ export function CampaignEditFormSummary({
         category: values.category,
         createdAt: campaign.createdAt,
         updatedAt: new Date(),
-        images: [
+        media: [
           {
-            id: 0,
-            imageUrl: values.bannerImage,
-            isMainImage: true,
-            campaignId: 0,
+            id: 'unsaved',
+            url: values.bannerImage,
+            mimeType: 'image/unknown',
           },
         ],
+        mediaOrder: ['unsaved'],
         slug: campaign.slug,
         location: values.location,
         paymentSummary: campaign.paymentSummary ?? {},

--- a/components/campaign/edit/index.tsx
+++ b/components/campaign/edit/index.tsx
@@ -38,7 +38,7 @@ export function CampaignEdit({ campaign }: { campaign: DbCampaign }) {
         ...campaign,
         location: campaign.location ?? '',
         category:
-          categories.find((category) => category.name === campaign.category)
+          categories.find((category) => category.id === campaign.category)
             ?.id ?? '',
       };
     },

--- a/components/campaign/main-image.tsx
+++ b/components/campaign/main-image.tsx
@@ -9,23 +9,53 @@ export function CampaignMainImage({
   campaign?: {
     title?: string;
     images?: { isMainImage?: boolean; imageUrl?: string | File | null }[];
+    media?: {
+      id: string;
+      url: string | File | null;
+      caption?: string | null;
+      mimeType: string;
+    }[];
+    mediaOrder?: string[] | null;
   };
 }) {
   const [mainImageObject, setMainImageObject] = useState<string | null>(null);
   const mainImage = useMemo(() => {
+    if (
+      Array.isArray(campaign?.media) &&
+      Array.isArray(campaign.mediaOrder) &&
+      campaign.media.length &&
+      campaign.mediaOrder.length
+    ) {
+      const firstMedia = campaign?.media
+        .filter(({ mimeType }) => mimeType.startsWith('image'))
+        .find(({ id }) => id === campaign.mediaOrder?.at(0));
+      if (firstMedia) {
+        return firstMedia;
+      }
+    }
     if (!Array.isArray(campaign?.images)) {
       return null;
     }
-    return campaign.images.find((img) => img.isMainImage) || campaign.images[0];
-  }, [campaign?.images]);
-  const imageUrl = useMemo(
-    () => mainImage?.imageUrl ?? '/images/placeholder.svg',
-    [mainImage],
-  );
-  const alt = useMemo(
-    () => campaign?.title ?? 'Illustration',
-    [campaign?.title],
-  );
+    const legacyImage =
+      campaign.images.find((img) => img.isMainImage) || campaign.images[0];
+    if (!legacyImage?.imageUrl) {
+      return null;
+    }
+    return {
+      id: 'none',
+      url: legacyImage.imageUrl,
+      caption: null,
+    };
+  }, [campaign?.images, campaign?.media, campaign?.mediaOrder]);
+  const imageUrl = useMemo(() => {
+    return mainImage?.url ?? '/images/placeholder.svg';
+  }, [mainImage]);
+  const alt = useMemo(() => {
+    if (typeof mainImage?.caption === 'string' && mainImage.caption.length) {
+      return mainImage.caption;
+    }
+    return campaign?.title ?? 'Illustration';
+  }, [campaign?.title, mainImage]);
   useEffect(() => {
     if (!imageUrl) {
       return;

--- a/components/round/card-dashboard.tsx
+++ b/components/round/card-dashboard.tsx
@@ -5,7 +5,7 @@ import {
   CardFooter,
 } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+
 import { Badge } from '@/components/ui/badge';
 import Link from 'next/link';
 import { Clock, Calendar, Users, DollarSign } from 'lucide-react';
@@ -15,6 +15,7 @@ import { useMemo } from 'react';
 import { useRoundStatus } from './use-status';
 import { useRoundTimeInfo } from './use-time-info';
 import { useAuth } from '@/contexts';
+import { RoundMainImageAvatar } from './main-image-avatar';
 
 export function RoundCardDashboard({
   round,
@@ -46,18 +47,8 @@ export function RoundCardDashboard({
       >
         <CardHeader className="border-b p-4">
           <div className="flex items-start gap-4">
-            <Avatar className="h-12 w-12 border">
-              {round.logoUrl ? (
-                <AvatarImage
-                  src={round.logoUrl}
-                  alt={`${round.title} logo`}
-                  className="object-cover"
-                />
-              ) : null}
-              <AvatarFallback className="text-lg font-semibold">
-                {round.title ? round.title.charAt(0).toUpperCase() : 'R'}
-              </AvatarFallback>
-            </Avatar>
+            <RoundMainImageAvatar round={round} />
+
             <div className="min-w-0 flex-1 space-y-1">
               <div className="flex items-center justify-between gap-2">
                 <h2 className="truncate text-lg font-semibold leading-tight tracking-tight">

--- a/components/round/card-full.tsx
+++ b/components/round/card-full.tsx
@@ -12,9 +12,6 @@ import {
   CardContent,
   CardHeader,
   CardFooter,
-  Avatar,
-  AvatarFallback,
-  AvatarImage,
   Badge,
   TabsTrigger,
 } from '@/components/ui';
@@ -22,6 +19,7 @@ import { RoundCardTabOverview } from './card-full-tab-overview';
 import { RoundCardTabCriteria } from './card-full-tab-criteria';
 import { RoundCardTabCampaigns } from './card-full-tab-campaigns';
 import { RoundCardTabRules } from './card-full-tab-rules';
+import { RoundMainImageAvatar } from './main-image-avatar';
 
 export function RoundCardFull({ round }: { round: GetRoundResponseInstance }) {
   const status = useRoundStatus(round);
@@ -46,18 +44,7 @@ export function RoundCardFull({ round }: { round: GetRoundResponseInstance }) {
       <Card className="flex h-full flex-col overflow-hidden rounded-lg border shadow-sm transition-shadow hover:shadow-md">
         <CardHeader className="border-b p-4">
           <div className="flex items-start gap-4">
-            <Avatar className="h-12 w-12 border">
-              {round.logoUrl ? (
-                <AvatarImage
-                  src={round.logoUrl}
-                  alt={`${round.title} logo`}
-                  className="object-cover"
-                />
-              ) : null}
-              <AvatarFallback className="text-lg font-semibold">
-                {round.title ? round.title.charAt(0).toUpperCase() : 'R'}
-              </AvatarFallback>
-            </Avatar>
+            <RoundMainImageAvatar round={round} />
             <div className="min-w-0 flex-1 space-y-1">
               <div className="flex items-center justify-between gap-2">
                 <h2 className="truncate text-lg font-semibold leading-tight tracking-tight">

--- a/components/round/card-minimal.tsx
+++ b/components/round/card-minimal.tsx
@@ -5,7 +5,7 @@ import {
   CardFooter,
 } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+
 import { Badge } from '@/components/ui/badge';
 import Link from 'next/link';
 import { Clock, Calendar, DollarSign } from 'lucide-react';
@@ -17,6 +17,7 @@ import { useAuth } from '@/contexts';
 import { useMemo } from 'react';
 import { DbCampaign } from '@/types/campaign';
 import { RoundCardCampaignRemoveButton } from './card-campaign-remove-button';
+import { RoundMainImageAvatar } from './main-image-avatar';
 
 export function RoundCardMinimal({
   round,
@@ -60,18 +61,7 @@ export function RoundCardMinimal({
       >
         <CardHeader className="border-b p-4">
           <div className="flex items-start gap-4">
-            <Avatar className="h-12 w-12 border">
-              {round.logoUrl ? (
-                <AvatarImage
-                  src={round.logoUrl}
-                  alt={`${round.title} logo`}
-                  className="object-cover"
-                />
-              ) : null}
-              <AvatarFallback className="text-lg font-semibold">
-                {round.title ? round.title.charAt(0).toUpperCase() : 'R'}
-              </AvatarFallback>
-            </Avatar>
+            <RoundMainImageAvatar round={round} />
             <div className="min-w-0 flex-1 space-y-1">
               <div className="flex items-center justify-between gap-2">
                 <h2 className="truncate text-lg font-semibold leading-tight tracking-tight">

--- a/components/round/card-select.tsx
+++ b/components/round/card-select.tsx
@@ -1,5 +1,5 @@
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+
 import { Badge } from '@/components/ui/badge';
 import { Clock, Calendar, DollarSign } from 'lucide-react';
 import { GetRoundResponseInstance } from '@/lib/api/types';
@@ -8,6 +8,7 @@ import { useRoundStatus } from './use-status';
 import { useRoundTimeInfo } from './use-time-info';
 import { useCallback } from 'react';
 import { cn } from '@/lib/utils';
+import { RoundMainImageAvatar } from './main-image-avatar';
 
 export function RoundCardSelect({
   round,
@@ -47,18 +48,7 @@ export function RoundCardSelect({
     >
       <CardHeader className="border-b p-4">
         <div className="flex items-start gap-4">
-          <Avatar className="h-12 w-12 border">
-            {round.logoUrl ? (
-              <AvatarImage
-                src={round.logoUrl}
-                alt={`${round.title} logo`}
-                className="object-cover"
-              />
-            ) : null}
-            <AvatarFallback className="text-lg font-semibold">
-              {round.title ? round.title.charAt(0).toUpperCase() : 'R'}
-            </AvatarFallback>
-          </Avatar>
+          <RoundMainImageAvatar round={round} />
           <div className="min-w-0 flex-1 space-y-1">
             <div className="flex items-center justify-between gap-2">
               <h2 className="truncate text-lg font-semibold leading-tight tracking-tight">

--- a/components/round/create/form-summary.tsx
+++ b/components/round/create/form-summary.tsx
@@ -47,7 +47,15 @@ export function RoundCreateFormSummary() {
         tags: [],
         blockchain: '',
         managerAddress: session?.data?.user.address,
-        logoUrl,
+        media: [
+          {
+            id: 'unsaved',
+            url: logoUrl,
+            mimeType: 'image/unknown',
+            caption: null,
+          },
+        ],
+        mediaOrder: ['unsaved'],
       } as GetRoundResponseInstance;
     } catch {
       return undefined;

--- a/components/round/main-image-avatar.tsx
+++ b/components/round/main-image-avatar.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import Image from 'next/image';
 import { useMemo, useEffect, useState } from 'react';
+import { Avatar, AvatarFallback, AvatarImage } from '../ui';
 
-export function RoundMainImage({
+export function RoundMainImageAvatar({
   round,
 }: {
   round?: {
@@ -60,24 +60,19 @@ export function RoundMainImage({
     }
   }, [imageUrl]);
   return (
-    <div className="lg:col-span-8">
-      <div className="space-y-6">
-        <div className="relative aspect-video overflow-hidden rounded-xl shadow-lg">
-          {(typeof imageUrl === 'string' || mainImageObject !== null) && (
-            <Image
-              src={
-                mainImageObject
-                  ? mainImageObject
-                  : (imageUrl as unknown as string)
-              }
-              alt={alt}
-              fill
-              className="object-cover"
-              priority
-            />
-          )}
-        </div>
-      </div>
-    </div>
+    <Avatar className="h-12 w-12 border">
+      {imageUrl ? (
+        <AvatarImage
+          src={
+            mainImageObject ? mainImageObject : (imageUrl as unknown as string)
+          }
+          alt={alt}
+          className="object-cover"
+        />
+      ) : null}
+      <AvatarFallback className="text-lg font-semibold">
+        {alt.charAt(0).toUpperCase()}
+      </AvatarFallback>
+    </Avatar>
   );
 }

--- a/lib/api/rounds.ts
+++ b/lib/api/rounds.ts
@@ -1,4 +1,4 @@
-import { Campaign, db, Round, RoundCampaigns } from '@/server/db';
+import { Campaign, db, Media, Round, RoundCampaigns } from '@/server/db';
 import {
   GetRoundResponseInstance,
   GetRoundsStatsResponse,
@@ -12,6 +12,7 @@ import { isFuture, isPast } from 'date-fns';
 export function mapRound(
   round: Round & {
     roundCampaigns?: (RoundCampaigns & { Campaign: Campaign })[];
+    media?: Media[];
   },
   status?: 'PENDING' | 'APPROVED' | 'REJECTED',
   roundCampaignId?: number,
@@ -22,6 +23,7 @@ export function mapRound(
     applicationStart,
     applicationClose,
     poolId,
+    imageUrl,
     ...roundWithoutDeprecated
   } = round;
   return {
@@ -42,6 +44,18 @@ export function mapRound(
         reviewedAt: roundCampaign.reviewedAt?.toISOString() ?? null,
         campaign: mapCampaign(roundCampaign.Campaign),
       })) ?? [],
+    media:
+      Array.isArray(round.media) && round.media.length
+        ? round.media
+        : [
+            {
+              id: 'unknown',
+              url: imageUrl as string,
+              mimeType: 'image/unknown',
+              caption: null,
+            },
+          ],
+    mediaOrder: round.mediaOrder ? (round.mediaOrder as string[]) : [],
     // transient
     recipientStatus: status,
     roundCampaignId: roundCampaignId,

--- a/lib/api/types/rounds/index.ts
+++ b/lib/api/types/rounds/index.ts
@@ -40,13 +40,19 @@ export interface GetRoundResponseInstance {
   startTime: string;
   endTime: string;
   blockchain: string;
-  logoUrl: string | null;
   createdAt: string;
   managerAddress: string;
   updatedAt: string;
   roundCampaigns?: GetRoundCampaignResponseInstance[];
   recipientStatus?: 'PENDING' | 'APPROVED' | 'REJECTED';
   roundCampaignId?: number;
+  media: {
+    id: string;
+    url: string;
+    mimeType: string;
+    caption: string | null;
+  }[];
+  mediaOrder: string[] | null;
 }
 export interface GetRoundResponse {
   round: GetRoundResponseInstance;

--- a/lib/hooks/useCampaigns.ts
+++ b/lib/hooks/useCampaigns.ts
@@ -146,10 +146,18 @@ interface IUpdateCampaignData {
   bannerImage?: File | null;
 }
 async function updateCampaignData(variables: IUpdateCampaignData) {
+  const formDataToSend = new FormData();
+  formDataToSend.append('campaignId', `${variables.campaignId}`);
+  formDataToSend.append('title', variables.title);
+  formDataToSend.append('description', variables.description);
+  formDataToSend.append('location', variables.location);
+  formDataToSend.append('category', variables.category);
+  if (variables.bannerImage) {
+    formDataToSend.append('bannerImage', variables.bannerImage);
+  }
   const response = await fetch('/api/campaigns/user', {
     method: 'PATCH',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(variables),
+    body: formDataToSend,
   });
 
   if (!response.ok) {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -247,13 +247,6 @@ async function main() {
     campaigns[i].id = campaign.id;
 
     // Assign an image from the local file system
-    await db.campaignImage.create({
-      data: {
-        imageUrl: `/campaign-images/${selectRandom(imageFiles)}`,
-        isMainImage: true,
-        campaignId: campaign.id,
-      },
-    });
     await db.media.create({
       data: {
         url: `/campaign-images/${selectRandom(imageFiles)}`,

--- a/types/campaign.ts
+++ b/types/campaign.ts
@@ -3,7 +3,14 @@ import {
   GetRoundResponseInstance,
 } from '@/lib/api/types';
 import { DisplayUserWithStates } from '@/lib/api/types/user';
-
+export interface Media {
+  id: string;
+  createdAt: Date;
+  state: 'CREATED' | 'UPLOADED' | 'BLOCKED';
+  url: string | File | null;
+  caption?: string | null;
+  mimeType: string;
+}
 export interface DbCampaign {
   id: number;
   title: string;
@@ -23,6 +30,8 @@ export interface DbCampaign {
   category?: string | null;
   // collections, // hidden in api
   images?: CampaignImage[];
+  media?: Media[];
+  mediaOrder?: string[] | null;
   updates?: CampaignUpdate[];
   comments?: DbComment[];
   // favorites, // hidden in api


### PR DESCRIPTION
- replace the imageUrl with the media/mediaOrder relation
- typescript magic to pass media/mediaOrder to components
- rewrite of [campaign|round]/main-image
- add round/main-image-avatar - same pattern
- rewrite all images[] creators to create a media[]+mediaOrder (previews)